### PR TITLE
fix account case mismatch between waldur and slurm

### DIFF
--- a/plugins/slurm/waldur_site_agent_slurm/client.py
+++ b/plugins/slurm/waldur_site_agent_slurm/client.py
@@ -149,7 +149,7 @@ class SlurmClient(SlurmClientInterface):
             parts = line.strip().split("|")
             if (
                 len(parts) > user_col
-                and parts[account_col].strip() == account
+                and parts[account_col].strip().lower() == account.lower()
                 and parts[user_col].strip() == ""
             ):
                 return parts[parent_col].strip() or None


### PR DESCRIPTION
Slurm accounts are case-insensitive:

```
$ sacctmgr show assoc account=2026_00A format=Account,ParentName,User -n -P
2026_00a|vub|
```

Currently this causes the following error on projects with capital letters because the agent tries to set the parent of the slurm account that is already properly set:
```
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]: Traceback (most recent call last):
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:   File "/usr/local/lib/python3.13/site-packages/waldur_site_agent/backend/clients.py", line 21, in execute_command
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:     return subprocess.check_output(command, stderr=subprocess.STDOUT, encoding="utf-8")
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:            ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:   File "/usr/lib64/python3.13/subprocess.py", line 472, in check_output
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:            ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:                **kwargs).stdout
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:                ^^^^^^^^^
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:   File "/usr/lib64/python3.13/subprocess.py", line 577, in run
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:     raise CalledProcessError(retcode, process.args,
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]:                              output=stdout, stderr=stderr)
Jul 01 23:20:16 srv01 waldur_site_agent[3940398]: subprocess.CalledProcessError: Command '['/usr/bin/sacctmgr', '--parsable2', '--noheader', '--immediate', 'modify', 'account', 'where', 'name=2026_00A', 'cluster=sofia', 'set', 'parent=vub']' returned non-zero exit status 1.
```